### PR TITLE
Add a missing import

### DIFF
--- a/src/setu32.rs
+++ b/src/setu32.rs
@@ -2,6 +2,7 @@
 //! This is a crate for the tiniest sets ever.
 
 mod iter;
+pub use iter::IntoIter;
 
 const fn num_bits<T>() -> u32 {
     std::mem::size_of::<T>() as u32 * 8


### PR DESCRIPTION
Currently, the code doesn't build for 32-bit targets (I found this out trying to build for WebAssembly). This is because while there's an import of `iter::IntoIter` into `setu64`, there isn't a corresponding one for `setu32`. By adding this, it compiles for 32-bit targets and also you can view the docs for `setu32::IntoIter`.